### PR TITLE
[버그] 쿠버네티스 아이콘 표시 되지 않는 현상

### DIFF
--- a/.mk/ui.mk
+++ b/.mk/ui.mk
@@ -9,6 +9,7 @@ UI_DIRS := \
 UI_V2_DIRS := \
 	statics/ui_v2/index.html \
 	statics/ui_v2/assets \
+	statics/ui_v2/assets/icons \
 	statics/ui_v2/dist \
 	statics/ui_v2/fonts
 


### PR DESCRIPTION
### PR 설명

넷 다이브에서 k8s 아이콘을 나타내기 위한 버그수정관련 PR 요청드립니다.

- [x] 넷다이브 쿠버네티스 아이콘 적용을 위한 mk(make file) 수정

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [x] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)

### 스크린샷
![image](https://user-images.githubusercontent.com/34114265/151093200-a4c1dc30-7ea9-43b1-b58a-f89ae76af795.png)


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->

k8s 기능을 사용하기 위해 ccvm에 설치되어 있는 netdive analyzer의 설정을 변경하고 kubeconfig를 등록한 후 테스트 하였고
쿠버네티스 노드 아이콘이 정상적으로 출력되는 것을 확인하였습니다.

```
$ vi ./netdive.yml

analyzer:
  topology:
    probes:
      - k8s
``` 
